### PR TITLE
test: isolate TestNewWriterComplex subtests with t.TempDir()

### DIFF
--- a/file_test.go
+++ b/file_test.go
@@ -187,13 +187,12 @@ func TestFileExistError(t *testing.T) {
 
 func TestNewWriterComplex(t *testing.T) {
 	t.Parallel()
-	// Test directory structure
-	baseDir := "testdata"
 
 	t.Run("CreatesWriterWhenDirectoryExists", func(t *testing.T) {
 		t.Parallel()
-		// Clean up after the tests
-		defer os.RemoveAll(baseDir)
+		// Use an isolated temp directory per subtest so parallel subtests
+		// don't clobber each other's setup (t.TempDir is auto-cleaned).
+		baseDir := t.TempDir()
 		testFilePath := filepath.Join(baseDir, "logs-exists", "output.log")
 		// Ensure the directory exists
 		err := os.MkdirAll(filepath.Dir(testFilePath), os.ModePerm)
@@ -214,15 +213,15 @@ func TestNewWriterComplex(t *testing.T) {
 
 	t.Run("FailsToCreateDirectory", func(t *testing.T) {
 		t.Parallel()
-		// Clean up after the tests
-		defer os.RemoveAll(baseDir)
+		// Use an isolated temp directory per subtest so parallel subtests
+		// don't clobber each other's setup (t.TempDir is auto-cleaned).
+		baseDir := t.TempDir()
 		// Create a file at the directory path to cause MkdirAll to fail
 		err := os.MkdirAll(baseDir, os.ModePerm)
 		require.NoError(t, err)
 		dir := filepath.Join(baseDir, "logs")
 		err = os.WriteFile(dir, []byte{}, 0o600) // Create a file where the directory should be
 		require.NoError(t, err)
-		defer os.Remove(dir)
 
 		f := file.NewWriter(dir + "/")
 		_, err = f.Write([]byte{})


### PR DESCRIPTION
Fixes the flaky GitHub Actions failure in `TestNewWriterComplex`.

## Root cause

The two subtests of `TestNewWriterComplex` shared a hardcoded `baseDir := "testdata"` and both ran with `t.Parallel()`, each registering `defer os.RemoveAll(baseDir)`. Because they run concurrently against the same on-disk directory, whichever subtest finished first wiped the entire `testdata` tree while the other was still setting up / writing. This produced two intermittent, timing-dependent failures:

- `CreatesWriterWhenDirectoryExists` → `mkdir testdata/logs-exists: no such file or directory` (sibling `RemoveAll` deleted `testdata` mid-`MkdirAll`).
- `FailsToCreateDirectory` → `failed to create file: open testdata/logs/: is a directory` did not contain `failed to create directory` (sibling `RemoveAll` deleted the `testdata/logs` blocker file, so `MkdirAll` succeeded and `os.Create` hit a directory instead).

This is a test-isolation race, not a bug in the code under test.

## Fix

Replace the shared `baseDir` and manual `RemoveAll` defers with a per-subtest `t.TempDir()`, which is unique, parallel-safe, and auto-cleaned by the testing framework. Also removed the now-redundant `defer os.Remove(dir)`.

## Verification

- Reproduced the failure locally before the fix (failed within ~50–200 runs, both error modes observed).
- After the fix: stable over 500 plain iterations and 50 `-race` iterations.
- Full `go test ./...` passes; `gofmt` clean; `go vet` clean; no leftover `testdata`/test files on disk.
- All 3 GitHub workflows on the fork report `success`:
  - Golang Build Github Actions
  - Golang Build Makefile Github Workflow
  - Golang Build Dagger Github Actions